### PR TITLE
fix(health): reject false positives from empty URLs and self-signed certs

### DIFF
--- a/skills/homelab-health/scripts/check-health.sh
+++ b/skills/homelab-health/scripts/check-health.sh
@@ -27,28 +27,32 @@ check_service() {
     local url="$2"
     local auth_header="${3:-}"
 
-    if [[ -z "$url" || "$url" == *"your-"* || "$url" == *"example"* ]]; then
+    # Strict: require a real scheme. Rejects "", "/health" (empty base + path), placeholders.
+    if [[ ! "$url" =~ ^https?:// || "$url" == *"your-"* || "$url" == *"example"* ]]; then
         results+=("{\"service\":\"$name\",\"status\":\"not_configured\",\"url\":\"\"}")
         return
     fi
 
+    # -k allows self-signed certs common on LAN homelab services (UniFi, etc).
     local http_code
     if [[ -n "$auth_header" ]]; then
-        http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        http_code=$(curl -sk -o /dev/null -w "%{http_code}" \
             --max-time "$TIMEOUT" \
             -H "$auth_header" \
             "$url" 2>/dev/null || echo "000")
     else
-        http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        http_code=$(curl -sk -o /dev/null -w "%{http_code}" \
             --max-time "$TIMEOUT" \
             "$url" 2>/dev/null || echo "000")
     fi
 
+    # Strict: only accept a well-formed HTTP status code (1xx-5xx).
+    # Rejects "000", "000000" (curl failure concat), and any other garbage.
     local status
-    if [[ "$http_code" == "000" ]]; then
-        status="unreachable"
-    else
+    if [[ "$http_code" =~ ^[1-5][0-9]{2}$ ]]; then
         status="reachable"
+    else
+        status="unreachable"
     fi
 
     # Escape URL for JSON


### PR DESCRIPTION
## Summary

Fixes three classification bugs in `skills/homelab-health/scripts/check-health.sh` where services were reported as `reachable` despite being unconfigured, and the reverse for services with self-signed TLS certs.

- **Scheme-based config guard.** `"${GOTIFY_URL:-}/health"` style call sites produce the literal `"/health"` when the base URL is unset. The previous `-z`/`your-`/`example` guard passed it through to curl, which returned `000` via `-w` AND exited non-zero, so `|| echo "000"` appended a second `000` → `"000000"`. The equality check `[[ "$http_code" == "000" ]]` didn't match, flipping the service to `reachable`. The new guard requires `^https?://`, which rejects both the empty and the path-only cases in one check.
- **Strict HTTP-code classifier.** `[[ "$http_code" =~ ^[1-5][0-9]{2}$ ]]` now rejects `000`, `000000`, and any other malformed curl output as unreachable.
- **`-k` for self-signed certs.** Local homelab services (UniFi controller on a LAN IP is the common case) frequently present self-signed certs. Without `-k`, curl fails with `000` and the service is incorrectly flagged unreachable. Adding `-k` matches the expectation of a homelab health checker.

Fixes #7.

## Test plan

- [x] `bash -n skills/homelab-health/scripts/check-health.sh` — syntax OK
- [x] With an empty `~/.claude-homelab/.env`, 17/18 services report `not_configured` (the 1 exception is the hardcoded `api.tailscale.com` URL, called out in #7 as a separate nit requiring a call-site change).
- [x] Tested against a live 18-service homelab. Before patch: 8 genuine ✓, 5 false-positive ✓ (gotify/linkding/memos/paperless with empty URLs; UniFi as 307 via misconfig), 5 `not_configured`. After patch: 9 ✓ (including UniFi self-signed, previously unreachable), 0 false positives, 9 `not_configured`.

## Notes for the maintainer

- The `-k` flag is the one judgment call. If you'd prefer strict TLS by default, I'm happy to gate it behind a `HEALTH_INSECURE_TLS=1` env opt-in — just say the word.
- The Tailscale call-site nit (`https://api.tailscale.com/api/v2/tailnet/${TAILSCALE_TAILNET:-}/devices` with an empty tailnet returns 3xx via redirect) is out of scope here because it needs a per-call non-empty guard rather than a classifier change. Happy to send a follow-up if you want it addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect health-check classifications by rejecting empty/placeholder URLs and handling self-signed TLS, so unconfigured services show not_configured and valid LAN services are reachable. Fixes #7.

- **Bug Fixes**
  - Require `https?://` scheme to treat empty, path-only (e.g. "/health"), and placeholder URLs as not_configured.
  - Mark reachable only when the HTTP code matches `^[1-5][0-9]{2}$`; treat `000`, `000000`, or malformed output as unreachable.
  - Add `-k` to `curl` to allow self-signed certs common on LAN services (e.g., UniFi).

<sup>Written for commit dfedfbba9a68dfa3790351c4de32ce383a0dbfc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

